### PR TITLE
add `log` method - fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const promiseTime = fn => {
 };
 
 const log = (fn, promise) => {
-	console.log(`Promise from ${fn.displayName || '[anonymous]'} resolved in ${promise.time} ms`);
+	console.log(`Promise from ${fn.displayName || fn.name || '[anonymous]'} resolved in ${promise.time} ms`);
 };
 
 module.exports = promiseTime;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const promiseTime = fn => {
 };
 
 const log = (fn, promise) => {
-	console.log(`Promise from ${fn.displayName} resolved in ${promise.time} ms`);
+	console.log(`Promise from ${fn.displayName || '[anonymous]'} resolved in ${promise.time} ms`);
 };
 
 module.exports = promiseTime;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-module.exports = fn => {
+const promiseTime = fn => {
 	const ret = function () {
 		const start = Date.now();
 		// TODO: use rest/spread when Node.js 6 is targeted
@@ -19,4 +19,31 @@ module.exports = fn => {
 	ret.displayName = fn.name;
 
 	return ret;
+};
+
+const log = (fn, promise) => {
+	console.log(`Promise from ${fn.displayName} resolved in ${promise.time} ms`);
+};
+
+module.exports = promiseTime;
+
+module.exports.log = fn => {
+	const wrapper = promiseTime(fn);
+
+	return function () {
+		// TODO: use rest/spread when Node.js 6 is targeted
+		const promise = wrapper.apply(null, arguments);
+
+		promise
+			.then(res => {
+				log(wrapper, promise);
+				return res;
+			})
+			.catch(err => {
+				log(wrapper, promise);
+				throw err;
+			});
+
+		return promise;
+	};
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "ava": "*",
     "delay": "^1.3.1",
+    "hook-std": "^0.2.0",
     "in-range": "^1.0.0",
     "xo": "*"
   },

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,10 @@ promise.then(() => {
 
 Returns a decorated version of `input` that when executed returns a `Promise` with a `time` property of the elapsed time in milliseconds.
 
+### promiseTime.log(input)
+
+Returns a decorated version of `input` that when executed logs the elapsed time in milliseconds of the `Promise`.
+
 #### input
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import delay from 'delay';
 import inRange from 'in-range';
+import hookStd from 'hook-std';
 import m from './';
 
 test('then', async t => {
@@ -21,4 +22,30 @@ test('catch', async t => {
 	} catch (err) {}
 
 	t.true(inRange(promise.time, 200, 250));
+});
+
+test.cb.serial('log', t => {
+	function myDelay(ms) {
+		return new Promise(resolve => {
+			setTimeout(resolve, ms);
+		});
+	}
+
+	const unhook = hookStd.stdout(output => {
+		unhook();
+		t.regex(output, /Promise from myDelay resolved in [0-9]+ ms/);
+		t.end();
+	});
+
+	m.log(myDelay)(200);
+});
+
+test.cb.serial('log aynonymous function', t => {
+	const unhook = hookStd.stdout(output => {
+		unhook();
+		t.regex(output, /Promise from \[anonymous\] resolved in [0-9]+ ms/);
+		t.end();
+	});
+
+	m.log(delay)(200);
 });

--- a/test.js
+++ b/test.js
@@ -25,15 +25,13 @@ test('catch', async t => {
 });
 
 test.cb.serial('log', t => {
-	function myDelay(ms) {
-		return new Promise(resolve => {
-			setTimeout(resolve, ms);
-		});
-	}
+	const myDelay = ms => new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
 
-	const unhook = hookStd.stdout(output => {
+	const unhook = hookStd.stdout({silent: true}, output => {
 		unhook();
-		t.regex(output, /Promise from myDelay resolved in [0-9]+ ms/);
+		t.regex(output, /Promise from myDelay resolved in \d+ ms/);
 		t.end();
 	});
 
@@ -41,7 +39,7 @@ test.cb.serial('log', t => {
 });
 
 test.cb.serial('log aynonymous function', t => {
-	const unhook = hookStd.stdout(output => {
+	const unhook = hookStd.stdout({silent: true}, output => {
 		unhook();
 		t.regex(output, /Promise from \[anonymous\] resolved in [0-9]+ ms/);
 		t.end();

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ test.cb.serial('log', t => {
 test.cb.serial('log aynonymous function', t => {
 	const unhook = hookStd.stdout({silent: true}, output => {
 		unhook();
-		t.regex(output, /Promise from \[anonymous\] resolved in [0-9]+ ms/);
+		t.regex(output, /Promise from \[anonymous\] resolved in \d+ ms/);
 		t.end();
 	});
 


### PR DESCRIPTION
Tried to implement #1.

Not sure if implemented correctly though so feel free to provide any feedback you have. (variable naming, structure, ...).

Not sure if there is a way to test this behaviour?

The only concern I have is that when I tried to do this:

``` js
await m.log(delay)(200);
```

It showed the following output:

> Promise from  resolved in 200 ms
